### PR TITLE
Update DatasetCoreFactory to match Dataset Factory

### DIFF
--- a/dataset.d.ts
+++ b/dataset.d.ts
@@ -51,7 +51,7 @@ export interface DatasetCoreFactory<OutQuad extends BaseQuad = Quad, InQuad exte
     /**
      * Returns a new dataset and imports all quads, if given.
      */
-    dataset(quads?: InQuad[]): D;
+    dataset(quads?: DatasetCore<InQuad> | InQuad[]): D;
 }
 
 export interface Dataset<OutQuad extends BaseQuad = Quad, InQuad extends BaseQuad = OutQuad> extends DatasetCore<OutQuad, InQuad> {


### PR DESCRIPTION
`DatasetFactory` accepts both a DataSet and an array of Quads, while `DatasetCoreFactory` only has an array of Quads. Note that this is correct according to the spec (https://rdf.js.org/dataset-spec/#datasetcorefactory-interface), but I would argue that consistency is better.