### PR TITLE
add typescript /// node reference

### DIFF
--- a/.changeset/red-boxes-return.md
+++ b/.changeset/red-boxes-return.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs/types": patch
+---
+
+The package did not work with DefinitelyTyped repository

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 export * from './data-model';
 export * from './stream';
 export * from './dataset';


### PR DESCRIPTION
This necessary for type packages on DefinitelyTyped to correctly import `@rdfjs/types`

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51756#issuecomment-853415157