### PR TITLE
Simplify callbacks

### DIFF
--- a/.changeset/seven-shrimps-build.md
+++ b/.changeset/seven-shrimps-build.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs/types": minor
+---
+
+Dataset: Use correct type of `dataset` in methods with callbacks

--- a/dataset.d.ts
+++ b/dataset.d.ts
@@ -148,7 +148,7 @@ export interface Dataset<OutQuad extends BaseQuad = Quad, InQuad extends BaseQua
      *
      * This method is aligned with `Array.prototype.reduce()` in ECMAScript-262.
      */
-    reduce<A = any>(iteratee: QuadReduceIteratee<A, OutQuad>['run'], initialValue?: A): A;
+    reduce<A = any>(callback: (accumulator: A, quad: OutQuad, dataset: this) => A, initialValue?: A): A;
 
     /**
      * Existential quantification method, tests whether some quads in the dataset pass the test implemented by the
@@ -217,11 +217,4 @@ export interface QuadMapIteratee<Q extends BaseQuad = Quad> {
      * The returned quad can be the given quad or a new one.
      */
     map(quad: Q, dataset: Dataset<Q>): Q;
-}
-
-export interface QuadReduceIteratee<A = any, Q extends BaseQuad = Quad> {
-    /**
-     * A callable function that can be executed on an accumulator and quad and returns a new accumulator.
-     */
-    run(accumulator: A, quad: Q, dataset: Dataset<Q>): A;
 }

--- a/dataset.d.ts
+++ b/dataset.d.ts
@@ -137,7 +137,7 @@ export interface Dataset<OutQuad extends BaseQuad = Quad, InQuad extends BaseQua
     /**
      * Returns a new dataset containing all quads returned by applying `iteratee` to each quad in the current dataset.
      */
-    map(iteratee: QuadMapIteratee<OutQuad>['map']): Dataset<OutQuad, InQuad>;
+    map(iteratee: (quad: OutQuad, dataset: Dataset<OutQuad>) => OutQuad): Dataset<OutQuad, InQuad>;
 
     /**
      * This method calls the `iteratee` on each `quad` of the `Dataset`. The first time the `iteratee` is called, the
@@ -208,13 +208,4 @@ export interface QuadFilterIteratee<Q extends BaseQuad = Quad> {
      * A callable function that returns `true` if the input quad passes the test this function implements.
      */
     test(quad: Q, dataset: Dataset<Q>): boolean;
-}
-
-export interface QuadMapIteratee<Q extends BaseQuad = Quad> {
-    /**
-     * A callable function that can be executed on a quad and returns a quad.
-     *
-     * The returned quad can be the given quad or a new one.
-     */
-    map(quad: Q, dataset: Dataset<Q>): Q;
 }

--- a/dataset.d.ts
+++ b/dataset.d.ts
@@ -106,14 +106,14 @@ export interface Dataset<OutQuad extends BaseQuad = Quad, InQuad extends BaseQua
      *
      * This method is aligned with `Array.prototype.every()` in ECMAScript-262.
      */
-    every(iteratee: QuadFilterIteratee<OutQuad>['test']): boolean;
+    every(iteratee: (quad: OutQuad, dataset: this) => boolean): boolean;
 
     /**
      * Creates a new dataset with all the quads that pass the test implemented by the provided `iteratee`.
      *
      * This method is aligned with Array.prototype.filter() in ECMAScript-262.
      */
-    filter(iteratee: QuadFilterIteratee<OutQuad>['test']): Dataset<OutQuad, InQuad>;
+    filter(iteratee: (quad: OutQuad, dataset: this) => boolean): Dataset<OutQuad, InQuad>;
 
     /**
      * Executes the provided `iteratee` once on each quad in the dataset.
@@ -158,7 +158,7 @@ export interface Dataset<OutQuad extends BaseQuad = Quad, InQuad extends BaseQua
      *
      * This method is aligned with `Array.prototype.some()` in ECMAScript-262.
      */
-    some(iteratee: QuadFilterIteratee<OutQuad>['test']): boolean;
+    some(iteratee: (quad: OutQuad, dataset: this) => boolean): boolean;
 
     /**
      * Returns the set of quads within the dataset as a host language native sequence, for example an `Array` in
@@ -201,11 +201,4 @@ export interface DatasetFactory<OutQuad extends BaseQuad = Quad, InQuad extends 
      * Returns a new dataset and imports all quads, if given.
      */
     dataset(quads?: Dataset<InQuad>|InQuad[]): D;
-}
-
-export interface QuadFilterIteratee<Q extends BaseQuad = Quad> {
-    /**
-     * A callable function that returns `true` if the input quad passes the test this function implements.
-     */
-    test(quad: Q, dataset: Dataset<Q>): boolean;
 }

--- a/dataset.d.ts
+++ b/dataset.d.ts
@@ -120,7 +120,7 @@ export interface Dataset<OutQuad extends BaseQuad = Quad, InQuad extends BaseQua
      *
      * This method is aligned with `Array.prototype.forEach()` in ECMAScript-262.
      */
-    forEach(iteratee: QuadRunIteratee<OutQuad>['run']): void;
+    forEach(callback: (quad: OutQuad, dataset: this) => void): void;
 
     /**
      * Imports all quads from the given stream into the dataset.
@@ -224,11 +224,4 @@ export interface QuadReduceIteratee<A = any, Q extends BaseQuad = Quad> {
      * A callable function that can be executed on an accumulator and quad and returns a new accumulator.
      */
     run(accumulator: A, quad: Q, dataset: Dataset<Q>): A;
-}
-
-export interface QuadRunIteratee<Q extends BaseQuad = Quad> {
-    /**
-     * A callable function that can be executed on a quad.
-     */
-    run(quad: Q, dataset: Dataset<Q>): void;
 }

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -236,7 +236,6 @@ function test_dataset() {
     const stream2: Stream<QuadBnode> = <any> {};
 
     const quadFilterIteratee: (quad: Quad, dataset: Dataset) => boolean = <any> {};
-    const quadMapIteratee: (quad: Quad, dataset: Dataset) => Quad = <any> {};
 
     const datasetFactory1: DatasetFactory = <any> {};
     const datasetFactory2: DatasetFactory<QuadBnode> = <any> {};
@@ -270,7 +269,7 @@ function test_dataset() {
     const dataset2Has: boolean = dataset2.has(quad);
     const dataset2Import: Promise<Dataset> = dataset2.import(stream1);
     const dataset2Intersection: Dataset = dataset2.intersection(dataset1);
-    const dataset2Map: Dataset = dataset2.map(quadMapIteratee);
+    const dataset2Map: Dataset = dataset2.map((quad: Quad, dataset: Dataset) => quad);
     const dataset2Match1: Dataset = dataset2.match();
     const dataset2Match2: Dataset = dataset2.match(term);
     const dataset2Match3: Dataset = dataset2.match(term, term);
@@ -309,7 +308,7 @@ function test_dataset() {
     const dataset4Has: boolean = dataset4.has(quadBnode);
     const dataset4Import: Promise<Dataset<QuadBnode>> = dataset4.import(stream2);
     const dataset4Intersection: Dataset<QuadBnode> = dataset4.intersection(dataset3);
-    const dataset4Map: Dataset<QuadBnode> = dataset4.map(quadMapIteratee);
+    const dataset4Map: Dataset<QuadBnode> = dataset4.map((quad: QuadBnode, dataset: Dataset<QuadBnode>) => quad);
     const dataset4Match1: Dataset<QuadBnode> = dataset4.match();
     const dataset4Match2: Dataset<QuadBnode> = dataset4.match(term);
     const dataset4Match3: Dataset<QuadBnode> = dataset4.match(term, term);

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -235,8 +235,6 @@ function test_dataset() {
     const stream1: Stream = <any> {};
     const stream2: Stream<QuadBnode> = <any> {};
 
-    const quadFilterIteratee: (quad: Quad, dataset: Dataset) => boolean = <any> {};
-
     const datasetFactory1: DatasetFactory = <any> {};
     const datasetFactory2: DatasetFactory<QuadBnode> = <any> {};
 
@@ -261,8 +259,8 @@ function test_dataset() {
     const dataset2DeleteMatches5: Dataset = dataset2.deleteMatches(term, term, term, term);
     const dataset2Difference: Dataset = dataset2.difference(dataset1);
     const dataset2Equals: boolean = dataset2.equals(dataset1);
-    const dataset2Every: boolean = dataset2.every(quadFilterIteratee);
-    const dataset2Filter: Dataset = dataset2.filter(quadFilterIteratee);
+    const dataset2Every: boolean = dataset2.every((quad: Quad, dataset: Dataset) => true);
+    const dataset2Filter: Dataset = dataset2.filter((quad: Quad, dataset: Dataset) => true);
     dataset2.forEach((quad: Quad, dataset: Dataset) => {
         return
     });
@@ -278,7 +276,7 @@ function test_dataset() {
     const dataset2Reduce1: string = dataset2.reduce((acc: string, quad: Quad, dataset: Dataset<Quad>) => acc);
     const dataset2Reduce2: boolean[] = dataset2.reduce((acc: boolean[], quad: Quad, dataset: Dataset<Quad>) => acc, []);
     const dataset2Reduce3: string = dataset2.reduce((acc: string, quad: Quad, dataset: Dataset<Quad>) => acc, '');
-    const dataset2Some: boolean = dataset2.some(quadFilterIteratee);
+    const dataset2Some: boolean = dataset2.some((quad: Quad, dataset: Dataset) => true);
     const dataset2ToArray: Quad[] = dataset2.toArray();
     const dataset2ToCanonical: string = dataset2.toCanonical();
     const dataset2ToStream: Stream = dataset2.toStream();
@@ -300,8 +298,8 @@ function test_dataset() {
     const dataset4DeleteMatches5: Dataset<QuadBnode> = dataset4.deleteMatches(term, term, term, term);
     const dataset4Difference: Dataset<QuadBnode> = dataset4.difference(dataset3);
     const dataset4Equals: boolean = dataset4.equals(dataset3);
-    const dataset4Every: boolean = dataset4.every(quadFilterIteratee);
-    const dataset4Filter: Dataset<QuadBnode> = dataset4.filter(quadFilterIteratee);
+    const dataset4Every: boolean = dataset4.every((quad: QuadBnode, dataset: Dataset<QuadBnode>) => true);
+    const dataset4Filter: Dataset<QuadBnode> = dataset4.filter((quad: QuadBnode, dataset: Dataset<QuadBnode>) => true);
     dataset4.forEach((quad: QuadBnode, dataset: Dataset<QuadBnode>) => {
         return
     });
@@ -317,7 +315,7 @@ function test_dataset() {
     const dataset4Reduce1: string = dataset4.reduce((acc: string, quad: QuadBnode, dataset: Dataset<QuadBnode>) => acc);
     const dataset4Reduce2: boolean[] = dataset4.reduce((acc: boolean[], quad: QuadBnode, dataset: Dataset<QuadBnode>) => acc, []);
     const dataset4Reduce3: string = dataset4.reduce((acc: string, quad: QuadBnode, dataset: Dataset<QuadBnode>) => acc, '');
-    const dataset4Some: boolean = dataset4.some(quadFilterIteratee);
+    const dataset4Some: boolean = dataset4.some((quad: QuadBnode, dataset: Dataset<QuadBnode>) => true);
     const dataset4ToArray: QuadBnode[] = dataset4.toArray();
     const dataset4ToCanonical: string = dataset4.toCanonical();
     const dataset4ToStream: Stream<QuadBnode> = dataset4.toStream();

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -237,8 +237,6 @@ function test_dataset() {
 
     const quadFilterIteratee: (quad: Quad, dataset: Dataset) => boolean = <any> {};
     const quadMapIteratee: (quad: Quad, dataset: Dataset) => Quad = <any> {};
-    const quadReduceToStringIteratee: (reduced: string, quad: Quad) => string = <any> {};
-    const quadReduceToArrayIteratee: (arr: boolean[], quad: Quad, dataset: Dataset) => boolean[] = <any> {};
 
     const datasetFactory1: DatasetFactory = <any> {};
     const datasetFactory2: DatasetFactory<QuadBnode> = <any> {};
@@ -278,9 +276,9 @@ function test_dataset() {
     const dataset2Match3: Dataset = dataset2.match(term, term);
     const dataset2Match4: Dataset = dataset2.match(term, term, term);
     const dataset2Match5: Dataset = dataset2.match(term, term, term, term);
-    const dataset2Reduce1: string = dataset2.reduce(quadReduceToStringIteratee);
-    const dataset2Reduce2: boolean[] = dataset2.reduce(quadReduceToArrayIteratee, []);
-    const dataset2Reduce3: string = dataset2.reduce(quadReduceToStringIteratee, '');
+    const dataset2Reduce1: string = dataset2.reduce((acc: string, quad: Quad, dataset: Dataset<Quad>) => acc);
+    const dataset2Reduce2: boolean[] = dataset2.reduce((acc: boolean[], quad: Quad, dataset: Dataset<Quad>) => acc, []);
+    const dataset2Reduce3: string = dataset2.reduce((acc: string, quad: Quad, dataset: Dataset<Quad>) => acc, '');
     const dataset2Some: boolean = dataset2.some(quadFilterIteratee);
     const dataset2ToArray: Quad[] = dataset2.toArray();
     const dataset2ToCanonical: string = dataset2.toCanonical();
@@ -317,11 +315,9 @@ function test_dataset() {
     const dataset4Match3: Dataset<QuadBnode> = dataset4.match(term, term);
     const dataset4Match4: Dataset<QuadBnode> = dataset4.match(term, term, term);
     const dataset4Match5: Dataset<QuadBnode> = dataset4.match(term, term, term, term);
-    const dataset4Reduce1: string = dataset4.reduce(quadReduceToStringIteratee);
-    const dataset4Reduce2: boolean[] = dataset4.reduce(quadReduceToArrayIteratee, []);
-    const dataset4Reduce3: string = dataset4.reduce(quadReduceToStringIteratee, '');
-    const dataset4Reduce4: string = dataset4.reduce(quadReduceToStringIteratee);
-    const dataset4Reduce5: string = dataset4.reduce(quadReduceToStringIteratee, '');
+    const dataset4Reduce1: string = dataset4.reduce((acc: string, quad: QuadBnode, dataset: Dataset<QuadBnode>) => acc);
+    const dataset4Reduce2: boolean[] = dataset4.reduce((acc: boolean[], quad: QuadBnode, dataset: Dataset<QuadBnode>) => acc, []);
+    const dataset4Reduce3: string = dataset4.reduce((acc: string, quad: QuadBnode, dataset: Dataset<QuadBnode>) => acc, '');
     const dataset4Some: boolean = dataset4.some(quadFilterIteratee);
     const dataset4ToArray: QuadBnode[] = dataset4.toArray();
     const dataset4ToCanonical: string = dataset4.toCanonical();

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -239,7 +239,6 @@ function test_dataset() {
     const quadMapIteratee: (quad: Quad, dataset: Dataset) => Quad = <any> {};
     const quadReduceToStringIteratee: (reduced: string, quad: Quad) => string = <any> {};
     const quadReduceToArrayIteratee: (arr: boolean[], quad: Quad, dataset: Dataset) => boolean[] = <any> {};
-    const quadForEachIteratee: (quad: Quad, dataset: Dataset) => void = <any> {};
 
     const datasetFactory1: DatasetFactory = <any> {};
     const datasetFactory2: DatasetFactory<QuadBnode> = <any> {};
@@ -267,7 +266,9 @@ function test_dataset() {
     const dataset2Equals: boolean = dataset2.equals(dataset1);
     const dataset2Every: boolean = dataset2.every(quadFilterIteratee);
     const dataset2Filter: Dataset = dataset2.filter(quadFilterIteratee);
-    dataset2.forEach(quadForEachIteratee);
+    dataset2.forEach((quad: Quad, dataset: Dataset) => {
+        return
+    });
     const dataset2Has: boolean = dataset2.has(quad);
     const dataset2Import: Promise<Dataset> = dataset2.import(stream1);
     const dataset2Intersection: Dataset = dataset2.intersection(dataset1);
@@ -304,7 +305,9 @@ function test_dataset() {
     const dataset4Equals: boolean = dataset4.equals(dataset3);
     const dataset4Every: boolean = dataset4.every(quadFilterIteratee);
     const dataset4Filter: Dataset<QuadBnode> = dataset4.filter(quadFilterIteratee);
-    dataset4.forEach(quadForEachIteratee);
+    dataset4.forEach((quad: QuadBnode, dataset: Dataset<QuadBnode>) => {
+        return
+    });
     const dataset4Has: boolean = dataset4.has(quadBnode);
     const dataset4Import: Promise<Dataset<QuadBnode>> = dataset4.import(stream2);
     const dataset4Intersection: Dataset<QuadBnode> = dataset4.intersection(dataset3);


### PR DESCRIPTION
Prompted by Blake's [message on Gitter](https://gitter.im/rdfjs/Representation-Task-Force?at=60e3cbbe8a40b11728478815) I thought I would take a second look and apparently the current types are imperfect

By inlining the callback/iteratee functions, the correct type of `dataset` argument can be used.