### PR TITLE
Fix @see from Quad to BaseQuad

### DIFF
--- a/.changeset/friendly-lies-suffer.md
+++ b/.changeset/friendly-lies-suffer.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs/types": patch
+---
+
+Documentation Fix: Update reference of Quad to BaseQuad in the definition of Term in order to align with the type declaration.

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -8,7 +8,7 @@
  * @see Literal
  * @see Variable
  * @see DefaultGraph
- * @see Quad
+ * @see BaseQuad
  */
 export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph | BaseQuad;
 


### PR DESCRIPTION
This looks like it was missed at some point when it was changed from Quad to BaseQuad in the type definition for Term