### PR TITLE
Add explicit license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rdfjs/types",
   "version": "1.0.1",
+  "license": "MIT",
   "types": "index.d.ts",
   "author": {
     "name": "RDF/JS Representation Task Force",


### PR DESCRIPTION
Otherwise license checking tools will "guess" based on the LICENSE file, this just makes it very explicit.