### PR TITLE
fix: problem with assumption that "quoted triples" are quads

### DIFF
--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -10,7 +10,7 @@
  * @see DefaultGraph
  * @see BaseQuad
  */
-export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph | BaseQuad;
+export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph | BaseQuad | Triple;
 
 /**
  * Contains an IRI.
@@ -128,12 +128,12 @@ export interface DefaultGraph {
 }
 
 /**
- * The subject, which is a NamedNode, BlankNode or Variable.
+ * The subject, which is a NamedNode, BlankNode, Variable, or a quoted triple.
  * @see NamedNode
  * @see BlankNode
  * @see Variable
  */
-export type Quad_Subject = NamedNode | BlankNode | Quad | Variable;
+export type Quad_Subject = NamedNode | BlankNode | Triple | Variable;
 
 /**
  * The predicate, which is a NamedNode or Variable.
@@ -143,13 +143,13 @@ export type Quad_Subject = NamedNode | BlankNode | Quad | Variable;
 export type Quad_Predicate = NamedNode | Variable;
 
 /**
- * The object, which is a NamedNode, Literal, BlankNode or Variable.
+ * The object, which is a NamedNode, Literal, BlankNode, Variable, or a quoted triple.
  * @see NamedNode
  * @see Literal
  * @see BlankNode
  * @see Variable
  */
-export type Quad_Object = NamedNode | Literal | BlankNode | Quad | Variable;
+export type Quad_Object = NamedNode | Literal | BlankNode | Triple | Variable;
 
 /**
  * The named graph, which is a DefaultGraph, NamedNode, BlankNode or Variable.
@@ -232,6 +232,9 @@ export interface Quad extends BaseQuad {
      */
     equals(other: Term | null | undefined): boolean;
 }
+
+export type BaseTriple = Omit<BaseQuad, 'graph'>
+export type Triple = Omit<Quad, 'graph'>
 
 /**
  * A factory for instantiating RDF terms and quads.

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -1,5 +1,5 @@
 import { BlankNode, DataFactory, Dataset, DatasetCore, DatasetCoreFactory, DatasetFactory, DefaultGraph, Literal,
-  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Term, Variable, Quad_Graph } from ".";
+  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Term, Variable, Quad_Graph, Triple, BaseTriple } from ".";
 import { EventEmitter } from "events";
 
 function test_terms() {
@@ -114,10 +114,14 @@ function test_datafactory_star() {
 
     // Decompose the triple
     if (quadBobAgeCertainty.subject.termType === 'Quad') {
-        const quadBobAge2: Quad = quadBobAgeCertainty.subject;
+        const quadBobAge2: Triple = quadBobAgeCertainty.subject;
 
         const equalToSelf: boolean = quadBobAge2.equals(quadBobAge);
         const notEqualToOtherType: boolean = quadBobAge2.equals(dataFactory.namedNode('ex:something:else'));
+
+        const dataset: DatasetCore = <any> {};
+        // @ts-expect-error
+        dataset.add(quadBobAge2);
     }
 }
 
@@ -138,10 +142,14 @@ function test_datafactory_star_basequad() {
 
     // Decompose the triple
     if (quadBobAgeCertainty.subject.termType === 'Quad') {
-        const quadBobAge2: BaseQuad = quadBobAgeCertainty.subject;
+        const quadBobAge2: BaseTriple = quadBobAgeCertainty.subject;
 
         const equalToSelf: boolean = quadBobAge2.equals(quadBobAge);
         const notEqualToOtherType: boolean = quadBobAge2.equals(dataFactory.namedNode('ex:something:else'));
+
+        const dataset: DatasetCore<BaseQuad> = <any> {};
+        // @ts-expect-error
+        dataset.add(quadBobAge2);
     }
 }
 


### PR DESCRIPTION
Based on the discussion in #34 I came to the realisation that when RDF* calls ["quoted triple"](https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#quoted-triples) is in fact not a quad. Consider a simple graph:

```turtle
PREFIX : <http://www.example.org/> 

<< :a :name "Alice" >> :statedBy :bob .
```

Currently, this cannot be exactly represented by RDF/JS, because we assume that `:a :name "Alice"` is a quad (`spog`), which it is not. It is only a triple. Thus, the code below should fail. At least by type checking

```ts
const dataset: DatasetCode = parseAboveExample()

const [ quad ] = dataset // there is only one quad

// Type Error: subject is a quoted triple, which should not be assignable to Quad
dataset.add(quad.subject)
```

This PR reintroduces `Triple` type which is simply `Quad` with `graph` removed (and its counterpart `BaseTriple`).

Note that while this is seemingly a breaking change, in fact it will not affect existing implementation (however they choose to interpret the `graph` property of a quoted triple). Typescript users will find this a breaking change but IMO its is closer to a bug fix of incorrectly interpreting RDF* spec when we first defined it in our type definitions