### PR TITLE
Add optional direction for literals

### DIFF
--- a/.changeset/famous-parrots-rush.md
+++ b/.changeset/famous-parrots-rush.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs/types": minor
+---
+
+Add optional direction for literals

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -74,6 +74,10 @@ export interface Literal {
      */
     language: string;
     /**
+     * the direction of the language-tagged string.
+     */
+    direction?: 'ltr' | 'rtl' | '';
+    /**
      * A NamedNode whose IRI represents the datatype of the literal.
      */
     datatype: NamedNode;
@@ -81,7 +85,7 @@ export interface Literal {
     /**
      * @param other The term to compare with.
      * @return True if and only if other has termType "Literal"
-     *                   and the same `value`, `language`, and `datatype`.
+     *                   and the same `value`, `language`, `direction`, and `datatype`.
      */
     equals(other: Term | null | undefined): boolean;
 }
@@ -254,16 +258,19 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
     blankNode(value?: string): BlankNode;
 
     /**
-     * @param                 value              The literal value.
-     * @param languageOrDatatype The optional language or datatype.
-     *                                                    If `languageOrDatatype` is a NamedNode,
-     *                                                    then it is used for the value of `NamedNode.datatype`.
-     *                                                    Otherwise `languageOrDatatype` is used for the value
-     *                                                    of `NamedNode.language`.
+     * @param value              The literal value.
+     * @param languageOrDatatype The optional language, datatype, or directional language.
+     *                           If `languageOrDatatype` is a NamedNode,
+     *                           then it is used for the value of `NamedNode.datatype`.
+     *                           If `languageOrDatatype` is a NamedNode, it is used for the value
+     *                           of `NamedNode.language`.
+     *                           Otherwise, it is used as a directional language,
+     *                           from which the language is set to `languageOrDatatype.language`
+     *                           and the direction to `languageOrDatatype.direction`.
      * @return A new instance of Literal.
      * @see Literal
      */
-    literal(value: string, languageOrDatatype?: string | NamedNode): Literal;
+    literal(value: string, languageOrDatatype?: string | NamedNode | DirectionalLanguage): Literal;
 
     /**
      * This method is optional.
@@ -287,4 +294,9 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
      * @see Quad
      */
     quad(subject: InQuad['subject'], predicate: InQuad['predicate'], object: InQuad['object'], graph?: InQuad['graph']): OutQuad;
+}
+
+export interface DirectionalLanguage {
+    language: string;
+    direction?: 'ltr' | 'rtl' | '';
 }

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -76,7 +76,7 @@ export interface Literal {
     /**
      * the direction of the language-tagged string.
      */
-    direction?: 'ltr' | 'rtl' | '';
+    direction?: 'ltr' | 'rtl' | '' | null;
     /**
      * A NamedNode whose IRI represents the datatype of the literal.
      */
@@ -298,5 +298,5 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
 
 export interface DirectionalLanguage {
     language: string;
-    direction?: 'ltr' | 'rtl' | '';
+    direction?: 'ltr' | 'rtl' | '' | null;
 }

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -36,6 +36,7 @@ function test_terms() {
     const termType3: string = literal.termType;
     const value3: string = literal.value;
     const language3: string = literal.language;
+    const dir3: 'ltr' | 'rtl' | '' | undefined = literal.direction;
     const datatype3: NamedNode = literal.datatype;
     let literalEqual: boolean = literal.equals(someTerm);
     literalEqual = literal.equals(null);
@@ -81,6 +82,12 @@ function test_datafactory() {
     const literal1: Literal = dataFactory.literal('abc');
     const literal2: Literal = dataFactory.literal('abc', 'en-us');
     const literal3: Literal = dataFactory.literal('abc', namedNode);
+    const literal4: Literal = dataFactory.literal('abc', { language: 'en-us' });
+    const literal5: Literal = dataFactory.literal('abc', { language: 'en-us', direction: 'ltr' });
+    const literal6: Literal = dataFactory.literal('abc', { language: 'en-us', direction: 'rtl' });
+    const literal7: Literal = dataFactory.literal('abc', { language: 'en-us', direction: '' });
+    // @ts-expect-error
+    const literal8: Literal = dataFactory.literal('abc', { language: 'en-us', direction: 'wrong' });
 
     const variable: Variable = dataFactory.variable ? dataFactory.variable('v1') : <any> {};
 

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -36,7 +36,7 @@ function test_terms() {
     const termType3: string = literal.termType;
     const value3: string = literal.value;
     const language3: string = literal.language;
-    const dir3: 'ltr' | 'rtl' | '' | undefined = literal.direction;
+    const dir3: 'ltr' | 'rtl' | '' | null | undefined = literal.direction;
     const datatype3: NamedNode = literal.datatype;
     let literalEqual: boolean = literal.equals(someTerm);
     literalEqual = literal.equals(null);


### PR DESCRIPTION
This adds typing support for base directions in literals, as discussed in https://github.com/rdfjs/data-model-spec/pull/175