### PR TITLE
Update stream.d.ts so Stream extends AsyncIterable<Quad>

### DIFF
--- a/stream.d.ts
+++ b/stream.d.ts
@@ -20,7 +20,7 @@ import { BaseQuad, Quad, Term } from './data-model';
  * Optional events:
  * * prefix(prefix: string, iri: RDF.NamedNode): This event is emitted every time a prefix is mapped to some IRI.
  */
-export interface Stream<Q extends BaseQuad = Quad> extends EventEmitter {
+export interface Stream<Q extends BaseQuad = Quad> extends EventEmitter, AsyncIterable<Q> {
     /**
      * This method pulls a quad out of the internal buffer and returns it.
      * If there is no quad available, then it will return null.


### PR DESCRIPTION
it might be a good idea to have it extend from stream.Readable too, but this is less opinionated. (node Readable implements AsyncIterable<Q>)