### PR TITLE
Mention deprecated package `rdf-js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ You may also create a [changeset](https://github.com/atlassian/changesets) file 
 
 ## What about @types/rdf-js?
 
-This package replaces typings previously managed in the [DefinitelyTyped repository](https://npm.im/@types/rdf-js). 
+This package replaces typings previously managed in the [DefinitelyTyped repository](https://npm.im/@types/rdf-js) and a later proxy package [rdf-js](https://npm.im/rdf-js).
 
-The old package wil be deprecated but continue to work for backwards compatibility but library maintainers are encouraged to use `@rdfjs/types` instead.
+Both these old packages are deprecated. They will continue to work for backwards compatibility but library maintainers are encouraged to use `@rdfjs/types` instead.


### PR DESCRIPTION
I have just deprecated the package `rdj-js` on NPM. It was high time, now that I recently also removed all of its usages from DefinitelyTyped (DefinitelyTyped/DefinitelyTyped#68132, DefinitelyTyped/DefinitelyTyped#68159)

I mention it alongside `@types/rdf-js` in the readme