### PR TITLE
Issue #45: Add missing spec methods to DataFactory interface

### DIFF
--- a/.changeset/afraid-donuts-retire.md
+++ b/.changeset/afraid-donuts-retire.md
@@ -2,4 +2,4 @@
 "@rdfjs/types": major
 ---
 
-Add missing methods to DataFactory interface
+Add missing methods `fromTerm` and `fromQuad` to the `DataFactory` interface

--- a/.changeset/afraid-donuts-retire.md
+++ b/.changeset/afraid-donuts-retire.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs/types": major
+---
+
+Add missing methods to DataFactory interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @rdfjs/types
 
-## 2.0.0
-
-### Major Changes
-
-- Add missing methods to DataFactory interface
-
 ## 1.1.1
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rdfjs/types
 
+## 2.0.0
+
+### Major Changes
+
+- Add missing methods to DataFactory interface
+
 ## 1.1.1
 
 ### Patch Changes

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -287,4 +287,18 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
      * @see Quad
      */
     quad(subject: InQuad['subject'], predicate: InQuad['predicate'], object: InQuad['object'], graph?: InQuad['graph']): OutQuad;
+
+    /**
+     * @param original The original term.
+     * @return A new instance of the term such that newTermInstance.equals(original) returns true.
+     * @see Term
+     */
+    fromTerm(original: Term): Term;
+
+    /**
+     * @param original The original quad.
+     * @return A new instance of the quad such that newQuadInstance.equals(original) returns true.
+     * @see Quad
+     */
+    fromQuad(original: InQuad): OutQuad;
 }

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -298,7 +298,7 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
     fromTerm<T extends Literal>(original: T): Literal;
     fromTerm<T extends Variable>(original: T): Variable;
     fromTerm<T extends DefaultGraph>(original: T): DefaultGraph;
-    fromTerm<T extends Quad>(original: T): OutQuad;
+    fromTerm<T extends BaseQuad>(original: T): OutQuad;
     fromTerm<T extends Term>(original: T): T;
 
     /**

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -293,7 +293,13 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
      * @return A new instance of the term such that newTermInstance.equals(original) returns true.
      * @see Term
      */
-    fromTerm(original: Term): Term;
+    fromTerm<T extends NamedNode>(original: T): NamedNode;
+    fromTerm<T extends BlankNode>(original: T): BlankNode;
+    fromTerm<T extends Literal>(original: T): Literal;
+    fromTerm<T extends Variable>(original: T): Variable;
+    fromTerm<T extends DefaultGraph>(original: T): DefaultGraph;
+    fromTerm<T extends Quad>(original: T): OutQuad;
+    fromTerm<T extends Term>(original: T): T;
 
     /**
      * @param original The original quad.

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -86,11 +86,16 @@ function test_datafactory() {
 
     const defaultGraph: DefaultGraph = dataFactory.defaultGraph();
 
-    const term1: Term = dataFactory.fromTerm(dataFactory.namedNode(""));
-    const term2: Term = dataFactory.fromTerm(dataFactory.blankNode());
-    const term3: Term = dataFactory.fromTerm(dataFactory.literal(""));
-    const term4: Term = dataFactory.fromTerm(dataFactory.variable ? dataFactory.variable("v1") : <any> {});
-    const term5: Term = dataFactory.fromTerm(dataFactory.defaultGraph());
+    type NamedNodeExt = NamedNode & { someProp: string };
+    const term1: NamedNode = dataFactory.fromTerm(<NamedNodeExt>{});
+    type BlankNodeExt = BlankNode & { someProp: string };
+    const term2: BlankNode = dataFactory.fromTerm(<BlankNodeExt>{});
+    type LiteralExt = Literal & { someProp: string };
+    const term3: Literal = dataFactory.fromTerm(<LiteralExt>{});
+    type VariableExt = Variable & { someProp: string };
+    const term4: Variable = dataFactory.fromTerm(<VariableExt> {});
+    type DefaultGraphExt = DefaultGraph & { someProp: string };
+    const term5: DefaultGraph = dataFactory.fromTerm(<DefaultGraphExt>{});
 
     const quadFromQuad: Term = dataFactory.fromQuad(dataFactory.quad(
         dataFactory.namedNode("x"),
@@ -135,7 +140,7 @@ function test_datafactory_star() {
         const notEqualToOtherType: boolean = quadBobAge2.equals(dataFactory.namedNode('ex:something:else'));
     }
 
-    const quadTerm: Term = dataFactory.fromTerm(quadBobAge);
+    const quadTerm: Quad = dataFactory.fromTerm(quadBobAge);
 }
 
 function test_datafactory_star_basequad() {
@@ -161,7 +166,7 @@ function test_datafactory_star_basequad() {
         const notEqualToOtherType: boolean = quadBobAge2.equals(dataFactory.namedNode('ex:something:else'));
     }
 
-    const baseQuadTerm: Term = dataFactory.fromTerm(quadBobAge);
+    const baseQuadTerm: Quad = dataFactory.fromTerm(quadBobAge);
 
     const baseQuad: BaseQuad = dataFactory.fromQuad(quadBobAge);
 }

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -166,9 +166,20 @@ function test_datafactory_star_basequad() {
         const notEqualToOtherType: boolean = quadBobAge2.equals(dataFactory.namedNode('ex:something:else'));
     }
 
-    const baseQuadTerm: Quad = dataFactory.fromTerm(quadBobAge);
+    const baseQuadTerm: BaseQuad = dataFactory.fromTerm(quadBobAge);
 
     const baseQuad: BaseQuad = dataFactory.fromQuad(quadBobAge);
+
+    // Test with regular Quad
+    const quadDataFactory: DataFactory<Quad> = <any> {};
+
+    const regularQuadBobAge: Quad = quadDataFactory.quad(
+        dataFactory.namedNode('ex:bob'),
+        dataFactory.namedNode('ex:age'),
+        dataFactory.literal('23'),
+    );
+
+    const quadTerm: Quad = quadDataFactory.fromTerm(regularQuadBobAge);
 }
 
 function test_stream() {

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -84,6 +84,21 @@ function test_datafactory() {
 
     const variable: Variable = dataFactory.variable ? dataFactory.variable('v1') : <any> {};
 
+    const defaultGraph: DefaultGraph = dataFactory.defaultGraph();
+
+    const term1: Term = dataFactory.fromTerm(dataFactory.namedNode(""));
+    const term2: Term = dataFactory.fromTerm(dataFactory.blankNode());
+    const term3: Term = dataFactory.fromTerm(dataFactory.literal(""));
+    const term4: Term = dataFactory.fromTerm(dataFactory.variable ? dataFactory.variable("v1") : <any> {});
+    const term5: Term = dataFactory.fromTerm(dataFactory.defaultGraph());
+
+    const quadFromQuad: Term = dataFactory.fromQuad(dataFactory.quad(
+        dataFactory.namedNode("x"),
+        dataFactory.namedNode("y"),
+        dataFactory.literal(""),
+        dataFactory.defaultGraph()
+    ));
+
     const term: NamedNode = <any> {};
     interface QuadBnode extends BaseQuad {
       subject: Term;
@@ -119,6 +134,8 @@ function test_datafactory_star() {
         const equalToSelf: boolean = quadBobAge2.equals(quadBobAge);
         const notEqualToOtherType: boolean = quadBobAge2.equals(dataFactory.namedNode('ex:something:else'));
     }
+
+    const quadTerm: Term = dataFactory.fromTerm(quadBobAge);
 }
 
 function test_datafactory_star_basequad() {
@@ -143,6 +160,10 @@ function test_datafactory_star_basequad() {
         const equalToSelf: boolean = quadBobAge2.equals(quadBobAge);
         const notEqualToOtherType: boolean = quadBobAge2.equals(dataFactory.namedNode('ex:something:else'));
     }
+
+    const baseQuadTerm: Term = dataFactory.fromTerm(quadBobAge);
+
+    const baseQuad: BaseQuad = dataFactory.fromQuad(quadBobAge);
 }
 
 function test_stream() {


### PR DESCRIPTION
As per issue #45 the `fromTerm` and `fromQuad` [DataFactory](https://rdf.js.org/data-model-spec/#datafactory-interface) methods defined by the RDF/JS DataModel specification are not reflected in the `@rdfjs/types` package.

This PR adds those methods.

That said, I am unsure in which context those methods would be used and didn't find an explanation of when it would be or whether the omission is intentional.