### PR TITLE
Issue #25: Only package declaration files

### DIFF
--- a/.changeset/sharp-trainers-sit.md
+++ b/.changeset/sharp-trainers-sit.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs/types": patch
+---
+
+Only package declaration files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rdfjs/types
 
+## 1.1.1
+
+### Patch Changes
+
+- Packaging Fix: Only package declaration files
+
 ## 1.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "license": "MIT",
   "types": "index.d.ts",
+  "files": [ "./**/*.d.ts" ],
   "author": {
     "name": "RDF/JS Representation Task Force",
     "url": "https://github.com/rdfjs/representation-task-force",


### PR DESCRIPTION
Proposed fix to #25: as per suggestions on my previous [PR#44](https://github.com/rdfjs/types/pull/44).

This change is minimal: add a `"files": [ "./**/*.d.ts" ]` pattern to `package.json` to identify files that need packaging.

With that change, `npm pack` results in the following :

<img width="627" alt="Screenshot 2024-09-10 at 13 18 02" src="https://github.com/user-attachments/assets/5b4c4309-9e4c-49c8-bfb8-e686d9ba8ca4">

