### PR TITLE
Use a files pattern that works for both npm and yarn

### DIFF
--- a/.changeset/rude-parents-search.md
+++ b/.changeset/rude-parents-search.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs/types": patch
+---
+
+Only package necessary files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @rdfjs/types
 
-## 1.1.1
-
-### Patch Changes
-
-- a631541: Only package declaration files
-
-## 1.1.1
-
-### Patch Changes
-
-- Packaging Fix: Only package declaration files
-
 ## 1.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rdfjs/types",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "license": "MIT",
   "types": "index.d.ts",
   "files": [
@@ -14,7 +14,8 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "test": "tsc --noEmit",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "changeset": "changeset"
   },
   "dependencies": {
     "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "types": "index.d.ts",
   "files": [
-    "./**/*.d.ts"
+    "**/*.d.ts"
   ],
   "author": {
     "name": "RDF/JS Representation Task Force",


### PR DESCRIPTION
Fixes issue #49.

This changes the `files` pattern in package.json to something that both `yarn` and `npm` recognise.