### PR TITLE
Remove generic parameters from `DataFactory#fromTerm()` overloads

### DIFF
--- a/.changeset/shy-buckets-work.md
+++ b/.changeset/shy-buckets-work.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs/types": patch
+---
+
+Remove generic parameters from `DataFactory#fromTerm()` overloads which caused incompatibility with `@rdfjs/types` v1

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -300,13 +300,12 @@ export interface DataFactory<OutQuad extends BaseQuad = Quad, InQuad extends Bas
      * @return A new instance of the term such that newTermInstance.equals(original) returns true.
      * @see Term
      */
-    fromTerm<T extends NamedNode>(original: T): NamedNode;
-    fromTerm<T extends BlankNode>(original: T): BlankNode;
-    fromTerm<T extends Literal>(original: T): Literal;
-    fromTerm<T extends Variable>(original: T): Variable;
-    fromTerm<T extends DefaultGraph>(original: T): DefaultGraph;
-    fromTerm<T extends BaseQuad>(original: T): OutQuad;
-    fromTerm<T extends Term>(original: T): T;
+    fromTerm(original: NamedNode): NamedNode;
+    fromTerm(original: BlankNode): BlankNode;
+    fromTerm(original: Literal): Literal;
+    fromTerm(original: Variable): Variable;
+    fromTerm(original: DefaultGraph): DefaultGraph;
+    fromTerm(original: BaseQuad): OutQuad;
 
     /**
      * @param original The original quad.


### PR DESCRIPTION
Ref: #45

The current implementation of the overloads is a little confused – the generics here [don't actually do anything](https://github.com/microsoft/DefinitelyTyped-tools/blob/main/packages/eslint-plugin/docs/rules/no-unnecessary-generics.md), and having multiple generic overloads like this has the potential to cause assignability headaches with the TypeScript compiler.

This change simply removes those generics. The catch-all signature is unnecessary, as all cases are already covered.