### PR TITLE
feat: equals type guards

### DIFF
--- a/.changeset/wicked-keys-behave.md
+++ b/.changeset/wicked-keys-behave.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs/types": minor
+---
+
+Added [`this`-based type guards](https://www.typescriptlang.org/docs/handbook/2/classes.html#this-based-type-guards) to `Term#equals` methods

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -29,7 +29,7 @@ export interface NamedNode<Iri extends string = string> {
      * @param other The term to compare with.
      * @return True if and only if other has termType "NamedNode" and the same `value`.
      */
-    equals(other: Term | null | undefined): boolean;
+    equals<T extends Term = Term>(other: T | null | undefined): this is T;
 }
 
 /**
@@ -52,7 +52,7 @@ export interface BlankNode {
      * @param other The term to compare with.
      * @return True if and only if other has termType "BlankNode" and the same `value`.
      */
-    equals(other: Term | null | undefined): boolean;
+    equals<T extends Term = Term>(other: T | null | undefined): this is T;
 }
 
 /**
@@ -87,7 +87,7 @@ export interface Literal {
      * @return True if and only if other has termType "Literal"
      *                   and the same `value`, `language`, `direction`, and `datatype`.
      */
-    equals(other: Term | null | undefined): boolean;
+    equals<T extends Term = Term>(other: T | null | undefined): this is T;
 }
 
 /**
@@ -107,7 +107,7 @@ export interface Variable {
      * @param other The term to compare with.
      * @return True if and only if other has termType "Variable" and the same `value`.
      */
-    equals(other: Term | null | undefined): boolean;
+    equals<T extends Term = Term>(other: T | null | undefined): this is T;
 }
 
 /**
@@ -128,7 +128,7 @@ export interface DefaultGraph {
      * @param other The term to compare with.
      * @return True if and only if other has termType "DefaultGraph".
      */
-    equals(other: Term | null | undefined): boolean;
+    equals<T extends Term = Term>(other: T | null | undefined): this is T;
 }
 
 /**
@@ -202,7 +202,7 @@ export interface BaseQuad {
      * @param other The term to compare with.
      * @return True if and only if the argument is a) of the same type b) has all components equal.
      */
-    equals(other: Term | null | undefined): boolean;
+    equals<T extends Term = Term>(other: T | null | undefined): this is T;
 }
 
 /**
@@ -234,7 +234,7 @@ export interface Quad extends BaseQuad {
      * @param other The term to compare with.
      * @return True if and only if the argument is a) of the same type b) has all components equal.
      */
-    equals(other: Term | null | undefined): boolean;
+    equals<T extends Term = Term>(other: T | null | undefined): this is T;
 }
 
 /**


### PR DESCRIPTION
It can be useful to use `equals` to narrow down a term's type. For example, in my code I have

```ts
if (functionPtr.term.equals(dashSparql.in) || functionPtr.term.equals(dashSparql.notin)) {
  return new InExpression(pointer.term, functionPtr.term, expressionList)
}

export class InExpression extends FunctionExpression {
  constructor(exprTerm: Term, funcTerm: typeof dashSparql.in | typeof dashSparql.notin, args: NodeExpression[]) {
}
```

See that `funcTerm` requires Named Node with one of very specific URIs. Right now, even though the type is ensured by the if statement, the type of `functionPtr.term` is a "plain" NamedNode, causing a TS error.

By adding `this is T` return type assertion to `equals`, this type is narrowed down in the body of the condition.