### PR TITLE
fix: usage with node module resolution

### DIFF
--- a/.changeset/soft-impalas-bow.md
+++ b/.changeset/soft-impalas-bow.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs/types": patch
+---
+
+Fix TS2834 on relative imports when projects use `moduleResolution` equal `Node16` or `NodeNext`

--- a/dataset.d.ts
+++ b/dataset.d.ts
@@ -1,8 +1,8 @@
 /* Dataset Interfaces */
 /* https://rdf.js.org/dataset-spec/ */
 
-import { Quad, BaseQuad, Term } from './data-model';
-import { Stream } from './stream';
+import { Quad, BaseQuad, Term } from './data-model.js';
+import { Stream } from './stream.js';
 
 export interface DatasetCore<OutQuad extends BaseQuad = Quad, InQuad extends BaseQuad = OutQuad> {
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-export type * from './data-model';
-export type * from './stream';
-export type * from './dataset';
-export type * from './query';
+export type * from './data-model.js';
+export type * from './stream.js';
+export type * from './dataset.js';
+export type * from './query.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rdfjs/types",
-  "version": "1.1.2",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rdfjs/types",
-      "version": "1.1.2",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"

--- a/query.d.ts
+++ b/query.d.ts
@@ -1,7 +1,7 @@
 /* Query Interfaces */
 /* https://rdf.js.org/query-spec/ */
 
-export * from './query/common';
-export * from './query/queryable';
+export * from './query/common.js';
+export * from './query/queryable.js';
 
 

--- a/query/common.d.ts
+++ b/query/common.d.ts
@@ -2,7 +2,7 @@
 /* https://rdf.js.org/query-spec/ */
 
 import { EventEmitter } from "events";
-import * as RDF from '../data-model';
+import * as RDF from '../data-model.js';
 
 /**
  * Helper union type for triple term names.

--- a/query/queryable.d.ts
+++ b/query/queryable.d.ts
@@ -1,8 +1,8 @@
 /* Query Interfaces - Queryable */
 /* https://rdf.js.org/query-spec/ */
 
-import * as RDF from '../data-model';
-import { Bindings, Query, ResultStream } from './common';
+import * as RDF from '../data-model.js';
+import { Bindings, Query, ResultStream } from './common.js';
 
 /**
  * Context properties provide a way to pass additional bits information to the query engine when executing a query.

--- a/rdf-js-query-tests.ts
+++ b/rdf-js-query-tests.ts
@@ -10,16 +10,16 @@ import {
     MetadataOpts,
     QueryStringContext,
     QueryAlgebraContext,
-    AllMetadataSupport, 
-    Query, 
-    Variable, 
-    ResultStream, 
-    Quad, 
-    StringSparqlQueryable, 
-    AlgebraSparqlQueryable, 
-    BindingsResultSupport, 
+    AllMetadataSupport,
+    Query,
+    Variable,
+    ResultStream,
+    Quad,
+    StringSparqlQueryable,
+    AlgebraSparqlQueryable,
+    BindingsResultSupport,
     QuadsResultSupport,
-} from ".";
+} from "./index.js";
 
 function test_bindings() {
     const df: DataFactory = <any> {};

--- a/rdf-js-tests.ts
+++ b/rdf-js-tests.ts
@@ -1,5 +1,5 @@
 import { BlankNode, DataFactory, Dataset, DatasetCore, DatasetCoreFactory, DatasetFactory, DefaultGraph, Literal,
-  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Term, Variable, Quad_Graph } from ".";
+  NamedNode, Quad, BaseQuad, Sink, Source, Store, Stream, Term, Variable, Quad_Graph } from "./index.js";
 import { EventEmitter } from "events";
 
 function test_terms() {

--- a/stream.d.ts
+++ b/stream.d.ts
@@ -4,7 +4,7 @@
 import * as stream from "stream";
 import { EventEmitter } from "events";
 
-import { BaseQuad, Quad, Term } from './data-model';
+import { BaseQuad, Quad, Term } from './data-model.js';
 
 // TODO: merge this with ResultStream upon the next major change
 /**


### PR DESCRIPTION
I'm not sure how this was never raised as issue, and maybe I'm brainfogged right now

In a new project, I set `moduleResolution` to `nodenext` and this breaks the types package because all imports must have `.js` extension.

This should fix...